### PR TITLE
Use Workload Identity

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,12 +9,17 @@ Use `make` to compile binaries for macOS and Linux.
 The environment variables below are required:
 
 ```
-FIRESTORE_CREDENTIALS # Path to the GCP service account JSON key
 FIRESTORE_PROJECT     # Name of the GCP project containing the Firestore project
 GITHUB_ORG_NAME       # Name of the GitHub Enterprise organisation
 GITHUB_TOKEN          # GitHub personal access token
 SLACK_ALERTS_CHANNEL  # Name of the Slack channel to post alerts to
 SLACK_WEBHOOK         # Used for accessing the Slack Incoming Webhooks API
+```
+
+The environment variable below is optional:
+
+```
+FIRESTORE_CREDENTIALS # Path to the GCP service account JSON key (used when running locally)
 ```
 
 ### Token Scopes

--- a/cmd/githubauditor/main.go
+++ b/cmd/githubauditor/main.go
@@ -11,10 +11,7 @@ import (
 )
 
 func main() {
-	firestoreCredentials := ""
-	if firestoreCredentials = os.Getenv("FIRESTORE_CREDENTIALS"); len(firestoreCredentials) == 0 {
-		log.Fatal("Missing FIRESTORE_CREDENTIALS environment variable")
-	}
+	firestoreCredentials := os.Getenv("FIRESTORE_CREDENTIALS")
 
 	firestoreProject := ""
 	if firestoreProject = os.Getenv("FIRESTORE_PROJECT"); len(firestoreProject) == 0 {
@@ -50,7 +47,11 @@ func main() {
 	// Using fmt rather than log so the output goes to STDOUT rather than STDERR.
 	fmt.Printf("Audit log API query returned %d results\n", len(events))
 
-	event.Process(events, firestoreCredentials, firestoreProject, slackAlertsChannel, slackWebHookURL)
+	if len(firestoreCredentials) > 0 {
+		event.ProcessWithCredentials(events, firestoreCredentials, firestoreProject, slackAlertsChannel, slackWebHookURL)
+	} else {
+		event.Process(events, firestoreProject, slackAlertsChannel, slackWebHookURL)
+	}
 
 	// Dump the results JSON to STDOUT so it can be ingested into SIEM software.
 	json, err := json.MarshalIndent(events, "", "  ")

--- a/pkg/googlecloud/firestore.go
+++ b/pkg/googlecloud/firestore.go
@@ -23,8 +23,23 @@ type (
 
 const firestoreCollection = "github-auditor"
 
-// NewClient instantiates a new Firestore client for the passed GCP project using the passed path to a JSON service account key file.
-func NewClient(projectID, credentialsFile string) *Client {
+// NewClient instantiates a new Firestore client for the passed GCP project.
+func NewClient(projectID string) *Client {
+	ctx := context.Background()
+	client, err := firestore.NewClient(ctx, projectID)
+	if err != nil {
+		log.Fatalf("Failed to instantiate Firestore client in project %s: %v", projectID, err)
+	}
+
+	return &Client{
+		projectID: projectID,
+		context:   &ctx,
+		client:    client,
+	}
+}
+
+// NewClientWithCredentials instantiates a new Firestore client for the passed GCP project using the passed path to a JSON service account key file.
+func NewClientWithCredentials(projectID, credentialsFile string) *Client {
 	ctx := context.Background()
 	client, err := firestore.NewClient(ctx, projectID, option.WithCredentialsFile(credentialsFile))
 	if err != nil {


### PR DESCRIPTION
Made the `FIRESTORE_CREDENTIALS` environment variable optional, so Workload Identity is used when running on a GKE cluster.